### PR TITLE
Fix unstable protocol version generation

### DIFF
--- a/messgen/version_protocol.py
+++ b/messgen/version_protocol.py
@@ -1,4 +1,14 @@
 import hashlib
+import json
+
+
+def _sanitize(obj):
+    """Recursively remove description fields and sort keys for deterministic hashing."""
+    if isinstance(obj, dict):
+        return {k: _sanitize(v) for k, v in sorted(obj.items()) if k != "descr"}
+    if isinstance(obj, list):
+        return [_sanitize(v) for v in obj]
+    return obj
 
 
 class VersionProtocol:
@@ -7,6 +17,7 @@ class VersionProtocol:
 
 
     def generate(self):
-        result = hashlib.md5(str(self._module).encode())
-
+        sanitized = _sanitize(self._module)
+        serialized = json.dumps(sanitized, sort_keys=True, separators=(",", ":"))
+        result = hashlib.md5(serialized.encode())
         return result.hexdigest()[0:6]


### PR DESCRIPTION
## Summary
- ensure deterministic protocol version by sanitizing module data

## Testing
- `make clean` in `tests`
- `make` *(fails: gtest missing)*

------
https://chatgpt.com/codex/tasks/task_e_688726be53bc8322ab6e4adc70775d9e